### PR TITLE
PR for #51 - Make the tests more language-agnostic

### DIFF
--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/ElseConditionalFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/ElseConditionalFilterTest.groovy
@@ -14,67 +14,30 @@ class ElseConditionalFilterTest extends ArthurTest {
 
     @Test
     void elseConditional_Go() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundElseConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifElseConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifElseConditional()", it.name)
-
-            new ElseConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundElseConditional)
-                foundElseConditional = true
-            }
-        }
-        assertTrue(foundElseConditional)
+        assertElseConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.go"))
     }
 
     @Test
     void elseConditional_Java() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundElseConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifElseConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Conditionals.ifElseConditional()", it.name)
-
-            new ElseConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundElseConditional)
-                foundElseConditional = true
-            }
-        }
-        assertTrue(foundElseConditional)
+        assertElseConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.java"),
+                "Conditionals.")
     }
 
     @Test
     void elseConditional_Javascript() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundElseConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifElseConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifElseConditional()", it.name)
-
-            new ElseConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundElseConditional)
-                foundElseConditional = true
-            }
-        }
-        assertTrue(foundElseConditional)
+        assertElseConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.js"))
     }
 
     @Test
     void elseConditional_Python() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.py")
+        assertElseConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.py"))
+    }
+
+    private static void assertElseConditionalPresent(File file) {
+        assertElseConditionalPresent(file, "")
+    }
+
+    private static void assertElseConditionalPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -82,7 +45,7 @@ class ElseConditionalFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("ifElseConditional")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifElseConditional()", it.name)
+            assertEquals(qualifiedName + "ifElseConditional()", it.name)
 
             new ElseConditionalFilter().getFilteredNodes(it).each {
                 assertFalse(foundElseConditional)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/ElseIfConditionalFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/ElseIfConditionalFilterTest.groovy
@@ -14,67 +14,30 @@ class ElseIfConditionalFilterTest extends ArthurTest {
 
     @Test
     void elseIfConditional_Go() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundElseIfConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifElseIfConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifElseIfConditional()", it.name)
-
-            new ElseIfConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundElseIfConditional)
-                foundElseIfConditional = true
-            }
-        }
-        assertTrue(foundElseIfConditional)
+        assertElseIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.go"))
     }
 
     @Test
     void elseIfConditional_Java() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundElseIfConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifElseIfConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Conditionals.ifElseIfConditional()", it.name)
-
-            new ElseIfConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundElseIfConditional)
-                foundElseIfConditional = true
-            }
-        }
-        assertTrue(foundElseIfConditional)
+        assertElseIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.java"),
+                "Conditionals.")
     }
 
     @Test
     void elseIfConditional_Javascript() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundElseIfConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifElseIfConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifElseIfConditional()", it.name)
-
-            new ElseIfConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundElseIfConditional)
-                foundElseIfConditional = true
-            }
-        }
-        assertTrue(foundElseIfConditional)
+        assertElseIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.js"))
     }
 
     @Test
     void elseIfConditional_Python() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.py")
+        assertElseIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.py"))
+    }
+
+    private static void assertElseIfConditionalPresent(File file) {
+        assertElseIfConditionalPresent(file, "")
+    }
+
+    private static void assertElseIfConditionalPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -82,7 +45,7 @@ class ElseIfConditionalFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("ifElseIfConditional")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifElseIfConditional()", it.name)
+            assertEquals(qualifiedName + "ifElseIfConditional()", it.name)
 
             new ElseIfConditionalFilter().getFilteredNodes(it).each {
                 assertFalse(foundElseIfConditional)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/IfConditionalFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/IfConditionalFilterTest.groovy
@@ -14,67 +14,30 @@ class IfConditionalFilterTest extends ArthurTest {
 
     @Test
     void ifConditional_Go() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundIfConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifConditional()", it.name)
-
-            new IfConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundIfConditional)
-                foundIfConditional = true
-            }
-        }
-        assertTrue(foundIfConditional)
+        assertIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.go"))
     }
 
     @Test
     void ifConditional_Java() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundIfConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Conditionals.ifConditional()", it.name)
-
-            new IfConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundIfConditional)
-                foundIfConditional = true
-            }
-        }
-        assertTrue(foundIfConditional)
+        assertIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.java"),
+                "Conditionals.")
     }
 
     @Test
     void ifConditional_Javascript() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundIfConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ifConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifConditional()", it.name)
-
-            new IfConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundIfConditional)
-                foundIfConditional = true
-            }
-        }
-        assertTrue(foundIfConditional)
+        assertIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.js"))
     }
 
     @Test
     void ifConditional_Python() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.py")
+        assertIfConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.py"))
+    }
+
+    private static void assertIfConditionalPresent(File file) {
+        assertIfConditionalPresent(file, "")
+    }
+
+    private static void assertIfConditionalPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -82,7 +45,7 @@ class IfConditionalFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("ifConditional")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ifConditional()", it.name)
+            assertEquals(qualifiedName + "ifConditional()", it.name)
 
             new IfConditionalFilter().getFilteredNodes(it).each {
                 assertFalse(foundIfConditional)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/SwitchCaseConditionalFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/SwitchCaseConditionalFilterTest.groovy
@@ -14,47 +14,25 @@ class SwitchCaseConditionalFilterTest extends ArthurTest {
 
     @Test
     void switchCaseConditional_Go() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundSwitchCaseConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("switchCaseConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("switchCaseConditional()", it.name)
-
-            new SwitchCaseConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundSwitchCaseConditional)
-                foundSwitchCaseConditional = true
-            }
-        }
-        assertTrue(foundSwitchCaseConditional)
+        assertSwitchCaseConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.go"))
     }
 
     @Test
     void switchCaseConditional_Java() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundSwitchCaseConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("switchCaseConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Conditionals.switchCaseConditional()", it.name)
-
-            new SwitchCaseConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundSwitchCaseConditional)
-                foundSwitchCaseConditional = true
-            }
-        }
-        assertTrue(foundSwitchCaseConditional)
+        assertSwitchCaseConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.java"),
+                "Conditionals.")
     }
 
     @Test
     void switchCaseConditional_Javascript() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.js")
+        assertSwitchCaseConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.js"))
+    }
+
+    private static void assertSwitchCaseConditionalPresent(File file) {
+        assertSwitchCaseConditionalPresent(file, "")
+    }
+
+    private static void assertSwitchCaseConditionalPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -62,7 +40,7 @@ class SwitchCaseConditionalFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("switchCaseConditional")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("switchCaseConditional()", it.name)
+            assertEquals(qualifiedName + "switchCaseConditional()", it.name)
 
             new SwitchCaseConditionalFilter().getFilteredNodes(it).each {
                 assertFalse(foundSwitchCaseConditional)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/SwitchConditionalFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/conditional/SwitchConditionalFilterTest.groovy
@@ -14,47 +14,25 @@ class SwitchConditionalFilterTest extends ArthurTest {
 
     @Test
     void switchConditional_Go() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundSwitchConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("switchConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("switchConditional()", it.name)
-
-            new SwitchConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundSwitchConditional)
-                foundSwitchConditional = true
-            }
-        }
-        assertTrue(foundSwitchConditional)
+        assertSwitchConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.go"))
     }
 
     @Test
     void switchConditional_Java() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundSwitchConditional = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("switchConditional")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Conditionals.switchConditional()", it.name)
-
-            new SwitchConditionalFilter().getFilteredNodes(it).each {
-                assertFalse(foundSwitchConditional)
-                foundSwitchConditional = true
-            }
-        }
-        assertTrue(foundSwitchConditional)
+        assertSwitchConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.java"),
+                "Conditionals.")
     }
 
     @Test
     void switchConditional_Javascript() {
-        def file = new File("src/test/resources/same/conditionals/Conditionals.js")
+        assertSwitchConditionalPresent(new File("src/test/resources/same/conditionals/Conditionals.js"))
+    }
+
+    private static void assertSwitchConditionalPresent(File file) {
+        assertSwitchConditionalPresent(file, "")
+    }
+
+    private static void assertSwitchConditionalPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -62,7 +40,7 @@ class SwitchConditionalFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("switchConditional")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("switchConditional()", it.name)
+            assertEquals(qualifiedName + "switchConditional()", it.name)
 
             new SwitchConditionalFilter().getFilteredNodes(it).each {
                 assertFalse(foundSwitchConditional)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/exception/TryFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/exception/TryFilterTest.groovy
@@ -14,123 +14,41 @@ class TryFilterTest extends ArthurTest {
 
     @Test
     void tryCatch_Java() {
-        def file = new File("src/test/resources/same/exceptions/Exceptions.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundTry = false
-        def foundCatch = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("tryCatch")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Exceptions.tryCatch()", it.name)
-
-            new TryFilter().getFilteredNodes(it).each {
-                assertFalse(foundTry)
-                foundTry = true
-            }
-            new CatchFilter().getFilteredNodes(it).each {
-                assertFalse(foundCatch)
-                foundCatch = true
-            }
-        }
-        assertTrue(foundTry)
-        assertTrue(foundCatch)
+        assertTryCatchPresent(new File("src/test/resources/same/exceptions/Exceptions.java"),
+                "Exceptions.")
     }
 
     @Test
     void tryCatchFinally_Java() {
-        def file = new File("src/test/resources/same/exceptions/Exceptions.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundTry = false
-        def foundCatch = false
-        def foundFinally = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("tryCatchFinally")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Exceptions.tryCatchFinally()", it.name)
-
-            new TryFilter().getFilteredNodes(it).each {
-                assertFalse(foundTry)
-                foundTry = true
-            }
-            new CatchFilter().getFilteredNodes(it).each {
-                assertFalse(foundCatch)
-                foundCatch = true
-            }
-            new FinallyFilter().getFilteredNodes(it).each {
-                assertFalse(foundFinally)
-                foundFinally = true
-            }
-        }
-        assertTrue(foundTry)
-        assertTrue(foundCatch)
-        assertTrue(foundFinally)
+        assertTryCatchFinallyPresent(new File("src/test/resources/same/exceptions/Exceptions.java"),
+                "Exceptions.")
     }
 
     @Test
     void tryCatch_Javascript() {
-        def file = new File("src/test/resources/same/exceptions/Exceptions.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundTry = false
-        def foundCatch = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("tryCatch")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("tryCatch()", it.name)
-
-            new TryFilter().getFilteredNodes(it).each {
-                assertFalse(foundTry)
-                foundTry = true
-            }
-            new CatchFilter().getFilteredNodes(it).each {
-                assertFalse(foundCatch)
-                foundCatch = true
-            }
-        }
-        assertTrue(foundTry)
-        assertTrue(foundCatch)
+        assertTryCatchPresent(new File("src/test/resources/same/exceptions/Exceptions.js"))
     }
 
     @Test
     void tryCatchFinally_Javascript() {
-        def file = new File("src/test/resources/same/exceptions/Exceptions.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundTry = false
-        def foundCatch = false
-        def foundFinally = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("tryCatchFinally")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("tryCatchFinally()", it.name)
-
-            new TryFilter().getFilteredNodes(it).each {
-                assertFalse(foundTry)
-                foundTry = true
-            }
-            new CatchFilter().getFilteredNodes(it).each {
-                assertFalse(foundCatch)
-                foundCatch = true
-            }
-            new FinallyFilter().getFilteredNodes(it).each {
-                assertFalse(foundFinally)
-                foundFinally = true
-            }
-        }
-        assertTrue(foundTry)
-        assertTrue(foundCatch)
-        assertTrue(foundFinally)
+        assertTryCatchFinallyPresent(new File("src/test/resources/same/exceptions/Exceptions.js"))
     }
 
     @Test
     void tryCatch_Python() {
-        def file = new File("src/test/resources/same/exceptions/Exceptions.py")
+        assertTryCatchPresent(new File("src/test/resources/same/exceptions/Exceptions.py"))
+    }
+
+    @Test
+    void tryCatchFinally_Python() {
+        assertTryCatchFinallyPresent(new File("src/test/resources/same/exceptions/Exceptions.py"))
+    }
+
+    private static void assertTryCatchPresent(File file) {
+        assertTryCatchPresent(file, "")
+    }
+
+    private static void assertTryCatchPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -139,7 +57,7 @@ class TryFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("tryCatch")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("tryCatch()", it.name)
+            assertEquals(qualifiedName + "tryCatch()", it.name)
 
             new TryFilter().getFilteredNodes(it).each {
                 assertFalse(foundTry)
@@ -154,9 +72,11 @@ class TryFilterTest extends ArthurTest {
         assertTrue(foundCatch)
     }
 
-    @Test
-    void tryCatchFinally_Python() {
-        def file = new File("src/test/resources/same/exceptions/Exceptions.py")
+    private static void assertTryCatchFinallyPresent(File file) {
+        assertTryCatchFinallyPresent(file, "")
+    }
+
+    private static void assertTryCatchFinallyPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -166,7 +86,7 @@ class TryFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("tryCatchFinally")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("tryCatchFinally()", it.name)
+            assertEquals(qualifiedName + "tryCatchFinally()", it.name)
 
             new TryFilter().getFilteredNodes(it).each {
                 assertFalse(foundTry)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/loop/DoWhileLoopFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/loop/DoWhileLoopFilterTest.groovy
@@ -14,27 +14,19 @@ class DoWhileLoopFilterTest extends ArthurTest {
 
     @Test
     void doWhileLoop_Java() {
-        def file = new File("src/test/resources/same/loops/Loops.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundDoWhileLoop = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("doWhileLoop")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Loops.doWhileLoop()", it.name)
-
-            new DoWhileLoopFilter().getFilteredNodes(it).each {
-                assertFalse(foundDoWhileLoop)
-                foundDoWhileLoop = true
-            }
-        }
-        assertTrue(foundDoWhileLoop)
+        assertDoWhileLoopPresent(new File("src/test/resources/same/loops/Loops.java"),"Loops.")
     }
 
     @Test
     void doWhileLoop_Javascript() {
-        def file = new File("src/test/resources/same/loops/Loops.js")
+        assertDoWhileLoopPresent(new File("src/test/resources/same/loops/Loops.js"))
+    }
+
+    private static void assertDoWhileLoopPresent(File file) {
+        assertDoWhileLoopPresent(file, "")
+    }
+
+    private static void assertDoWhileLoopPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -42,7 +34,7 @@ class DoWhileLoopFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("doWhileLoop")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("doWhileLoop()", it.name)
+            assertEquals(qualifiedName + "doWhileLoop()", it.name)
 
             new DoWhileLoopFilter().getFilteredNodes(it).each {
                 assertFalse(foundDoWhileLoop)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/loop/ForEachLoopFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/loop/ForEachLoopFilterTest.groovy
@@ -14,47 +14,25 @@ class ForEachLoopFilterTest extends ArthurTest {
 
     @Test
     void forEachLoop_Go() {
-        def file = new File("src/test/resources/same/loops/Loops.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundForEachLoop = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("forEachLoop")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("forEachLoop()", it.name)
-
-            new ForEachLoopFilter().getFilteredNodes(it).each {
-                assertFalse(foundForEachLoop)
-                foundForEachLoop = true
-            }
-        }
-        assertTrue(foundForEachLoop)
+        assertForEachLoopPresent(new File("src/test/resources/same/loops/Loops.go"))
     }
 
     @Test
     void forEachLoop_Java() {
-        def file = new File("src/test/resources/same/loops/Loops.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundForEachLoop = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("forEachLoop")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Loops.forEachLoop()", it.name)
-
-            new ForEachLoopFilter().getFilteredNodes(it).each {
-                assertFalse(foundForEachLoop)
-                foundForEachLoop = true
-            }
-        }
-        assertTrue(foundForEachLoop)
+        assertForEachLoopPresent(new File("src/test/resources/same/loops/Loops.java"),
+                "Loops.")
     }
 
     @Test
     void forEachLoop_Javascript() {
-        def file = new File("src/test/resources/same/loops/Loops.js")
+        assertForEachLoopPresent(new File("src/test/resources/same/loops/Loops.js"))
+    }
+
+    private static void assertForEachLoopPresent(File file) {
+        assertForEachLoopPresent(file, "")
+    }
+
+    private static void assertForEachLoopPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -62,7 +40,7 @@ class ForEachLoopFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("forEachLoop")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("forEachLoop()", it.name)
+            assertEquals(qualifiedName + "forEachLoop()", it.name)
 
             new ForEachLoopFilter().getFilteredNodes(it).each {
                 assertFalse(foundForEachLoop)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/loop/WhileLoopFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/loop/WhileLoopFilterTest.groovy
@@ -14,67 +14,30 @@ class WhileLoopFilterTest extends ArthurTest {
 
     @Test
     void whileLoop_Go() {
-        def file = new File("src/test/resources/same/loops/Loops.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundWhileLoop = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("whileLoop")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("whileLoop()", it.name)
-
-            new WhileLoopFilter().getFilteredNodes(it).each {
-                assertFalse(foundWhileLoop)
-                foundWhileLoop = true
-            }
-        }
-        assertTrue(foundWhileLoop)
+        assertWhileLoopPresent(new File("src/test/resources/same/loops/Loops.go"))
     }
 
     @Test
     void whileLoop_Java() {
-        def file = new File("src/test/resources/same/loops/Loops.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundWhileLoop = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("whileLoop")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Loops.whileLoop()", it.name)
-
-            new WhileLoopFilter().getFilteredNodes(it).each {
-                assertFalse(foundWhileLoop)
-                foundWhileLoop = true
-            }
-        }
-        assertTrue(foundWhileLoop)
+        assertWhileLoopPresent(new File("src/test/resources/same/loops/Loops.java"),
+                "Loops.")
     }
 
     @Test
     void whileLoop_Javascript() {
-        def file = new File("src/test/resources/same/loops/Loops.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundWhileLoop = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("whileLoop")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("whileLoop()", it.name)
-
-            new WhileLoopFilter().getFilteredNodes(it).each {
-                assertFalse(foundWhileLoop)
-                foundWhileLoop = true
-            }
-        }
-        assertTrue(foundWhileLoop)
+        assertWhileLoopPresent(new File("src/test/resources/same/loops/Loops.js"))
     }
 
     @Test
     void whileLoop_Python() {
-        def file = new File("src/test/resources/same/loops/Loops.py")
+        assertWhileLoopPresent(new File("src/test/resources/same/loops/Loops.py"))
+    }
+
+    private static void assertWhileLoopPresent(File file) {
+        assertWhileLoopPresent(file, "")
+    }
+
+    private static void assertWhileLoopPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -82,7 +45,7 @@ class WhileLoopFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("whileLoop")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("whileLoop()", it.name)
+            assertEquals(qualifiedName + "whileLoop()", it.name)
 
             new WhileLoopFilter().getFilteredNodes(it).each {
                 assertFalse(foundWhileLoop)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/logical/AndOperatorFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/logical/AndOperatorFilterTest.groovy
@@ -14,70 +14,33 @@ class AndOperatorFilterTest extends ArthurTest {
 
     @Test
     void andOperator_Go() {
-        def file = new File("src/test/resources/same/operators/Operators.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundAndOperator = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("andOperator")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("andOperator()", it.name)
-
-            new AndOperatorFilter().getFilteredNodes(it).each {
-                assertFalse(foundAndOperator)
-                assertEquals("&&", it.token)
-                foundAndOperator = true
-            }
-        }
-        assertTrue(foundAndOperator)
+        assertAndOperatorPresent(new File("src/test/resources/same/operators/Operators.go"),
+                "&&")
     }
 
     @Test
     void andOperator_Java() {
-        def file = new File("src/test/resources/same/operators/Operators.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundAndOperator = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("andOperator")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Operators.andOperator()", it.name)
-
-            new AndOperatorFilter().getFilteredNodes(it).each {
-                assertFalse(foundAndOperator)
-                assertEquals("&&", it.token)
-                foundAndOperator = true
-            }
-        }
-        assertTrue(foundAndOperator)
+        assertAndOperatorPresent(new File("src/test/resources/same/operators/Operators.java"),
+                "&&", "Operators.")
     }
 
     @Test
     void andOperator_Javascript() {
-        def file = new File("src/test/resources/same/operators/Operators.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundAndOperator = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("andOperator")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("andOperator()", it.name)
-
-            new AndOperatorFilter().getFilteredNodes(it).each {
-                assertFalse(foundAndOperator)
-                assertEquals("&&", it.token)
-                foundAndOperator = true
-            }
-        }
-        assertTrue(foundAndOperator)
+        assertAndOperatorPresent(new File("src/test/resources/same/operators/Operators.js"),
+                "&&")
     }
 
     @Test
     void andOperator_Python() {
-        def file = new File("src/test/resources/same/operators/Operators.py")
+        assertAndOperatorPresent(new File("src/test/resources/same/operators/Operators.py"),
+                "and")
+    }
+
+    private static void assertAndOperatorPresent(File file, String andToken) {
+        assertAndOperatorPresent(file, andToken, "")
+    }
+
+    private static void assertAndOperatorPresent(File file, String andToken, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -85,11 +48,11 @@ class AndOperatorFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("andOperator")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("andOperator()", it.name)
+            assertEquals(qualifiedName + "andOperator()", it.name)
 
             new AndOperatorFilter().getFilteredNodes(it).each {
                 assertFalse(foundAndOperator)
-                assertEquals("and", it.token)
+                assertEquals(andToken, it.token)
                 foundAndOperator = true
             }
         }

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/logical/OrOperatorFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/logical/OrOperatorFilterTest.groovy
@@ -14,70 +14,33 @@ class OrOperatorFilterTest extends ArthurTest {
 
     @Test
     void orOperator_Go() {
-        def file = new File("src/test/resources/same/operators/Operators.go")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundOrOperator = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("orOperator")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("orOperator()", it.name)
-
-            new OrOperatorFilter().getFilteredNodes(it).each {
-                assertFalse(foundOrOperator)
-                assertEquals("||", it.token)
-                foundOrOperator = true
-            }
-        }
-        assertTrue(foundOrOperator)
+        assertOrOperatorPresent(new File("src/test/resources/same/operators/Operators.go"),
+                "||", "")
     }
 
     @Test
     void orOperator_Java() {
-        def file = new File("src/test/resources/same/operators/Operators.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundOrOperator = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("orOperator")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Operators.orOperator()", it.name)
-
-            new OrOperatorFilter().getFilteredNodes(it).each {
-                assertFalse(foundOrOperator)
-                assertEquals("||", it.token)
-                foundOrOperator = true
-            }
-        }
-        assertTrue(foundOrOperator)
+        assertOrOperatorPresent(new File("src/test/resources/same/operators/Operators.java"),
+                "||", "Operators.")
     }
 
     @Test
     void orOperator_Javascript() {
-        def file = new File("src/test/resources/same/operators/Operators.js")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundOrOperator = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("orOperator")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("orOperator()", it.name)
-
-            new OrOperatorFilter().getFilteredNodes(it).each {
-                assertFalse(foundOrOperator)
-                assertEquals("||", it.token)
-                foundOrOperator = true
-            }
-        }
-        assertTrue(foundOrOperator)
+        assertOrOperatorPresent(new File("src/test/resources/same/operators/Operators.js"),
+                "||")
     }
 
     @Test
     void orOperator_Python() {
-        def file = new File("src/test/resources/same/operators/Operators.py")
+        assertOrOperatorPresent(new File("src/test/resources/same/operators/Operators.py"),
+                "or", "")
+    }
+
+    private static void assertOrOperatorPresent(File file, String orToken) {
+        assertOrOperatorPresent(file, orToken, "")
+    }
+
+    private static void assertOrOperatorPresent(File file, String orToken, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -85,11 +48,11 @@ class OrOperatorFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("orOperator")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("orOperator()", it.name)
+            assertEquals(qualifiedName + "orOperator()", it.name)
 
             new OrOperatorFilter().getFilteredNodes(it).each {
                 assertFalse(foundOrOperator)
-                assertEquals("or", it.token)
+                assertEquals(orToken, it.token)
                 foundOrOperator = true
             }
         }

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/misc/TernaryOperatorFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/misc/TernaryOperatorFilterTest.groovy
@@ -14,27 +14,20 @@ class TernaryOperatorFilterTest extends ArthurTest {
 
     @Test
     void ternaryOperator_Java() {
-        def file = new File("src/test/resources/same/operators/Operators.java")
-        def language = SourceLanguage.getSourceLanguage(file)
-        def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
-
-        def foundTernaryOperator = false
-        def functionFilter = new FunctionFilter()
-        def nameFilter = new NameFilter("ternaryOperator")
-        MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("Operators.ternaryOperator()", it.name)
-
-            new TernaryOperatorFilter().getFilteredNodes(it).each {
-                assertFalse(foundTernaryOperator)
-                foundTernaryOperator = true
-            }
-        }
-        assertTrue(foundTernaryOperator)
+        assertTernaryOperatorPresent(new File("src/test/resources/same/operators/Operators.java"),
+                "Operators.")
     }
 
     @Test
     void ternaryOperator_Javascript() {
-        def file = new File("src/test/resources/same/operators/Operators.js")
+        assertTernaryOperatorPresent(new File("src/test/resources/same/operators/Operators.js"))
+    }
+
+    private static void assertTernaryOperatorPresent(File file) {
+        assertTernaryOperatorPresent(file, "")
+    }
+
+    private static void assertTernaryOperatorPresent(File file, String qualifiedName) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 
@@ -42,7 +35,7 @@ class TernaryOperatorFilterTest extends ArthurTest {
         def functionFilter = new FunctionFilter()
         def nameFilter = new NameFilter("ternaryOperator")
         MultiFilter.matchAll(functionFilter, nameFilter).getFilteredNodes(language, resp.uast).each {
-            assertEquals("ternaryOperator()", it.name)
+            assertEquals(qualifiedName + "ternaryOperator()", it.name)
 
             new TernaryOperatorFilter().getFilteredNodes(it).each {
                 assertFalse(foundTernaryOperator)

--- a/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/relational/EqualTypeOperatorFilterTest.groovy
+++ b/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/relational/EqualTypeOperatorFilterTest.groovy
@@ -22,7 +22,7 @@ class EqualTypeOperatorFilterTest extends ArthurTest {
         assertEqualTypeOperatorPresent(new File("src/test/resources/same/operators/Operators.php"))
     }
 
-    private void assertEqualTypeOperatorPresent(File file) {
+    private static void assertEqualTypeOperatorPresent(File file) {
         def language = SourceLanguage.getSourceLanguage(file)
         def resp = client.parse(file.name, file.text, language.key, Encoding.UTF8$.MODULE$)
 


### PR DESCRIPTION
#51 

> ...would be because sometimes the tests assert slightly different naming. For example, Java expects names to be fully qualified. If it can be made better, go for it.

I wasn't able to find a better way; open to other thoughts. I also made a similar adjustment in the tests below:

- [AndOperatorFilterTest](https://github.com/chess-equality/Arthur/blob/dd547b36e877d2d826ae2af4b77f8460c27d239c/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/logical/AndOperatorFilterTest.groovy#L55)
- [OrOperatorFilterTest](https://github.com/chess-equality/Arthur/blob/dd547b36e877d2d826ae2af4b77f8460c27d239c/src/test/groovy/com/codebrig/arthur/observe/structure/filter/operator/logical/OrOperatorFilterTest.groovy#L55)